### PR TITLE
Moved FIRBoundaries.dat explanation

### DIFF
--- a/FIRBoundaries.dat
+++ b/FIRBoundaries.dat
@@ -1,5 +1,3 @@
-;ICAO|IsOceanic|IsExtension|PointCount|MinLat|MinLon|MaxLat|MaxLon|CenterLat|CenterLon
-;Lat|Lon - One per line. As many as PointCount indicates.
 AGGG|0|0|12|-14.000000|155.000000|-4.833333|166.875000|-9.416667|160.937500
 -4.833333|159.000000
 -4.833333|160.000000

--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ Please send an email to, or have your Region, Division, or FIR/ARTCC Leadership 
 
 <br>
 
+# FIRBoundaries.dat
+
+```ICAO|IsOceanic|IsExtension|PointCount|MinLat|MinLon|MaxLat|MaxLon|CenterLat|CenterLon```
+``Lat|Lon`` - One per line. As many as PointCount indicates.
+
+<br>
+
 # Data Installation
 
 1) Start Menu

--- a/README.md
+++ b/README.md
@@ -18,8 +18,10 @@ Please send an email to, or have your Region, Division, or FIR/ARTCC Leadership 
 
 # FIRBoundaries.dat
 
-```ICAO|IsOceanic|IsExtension|PointCount|MinLat|MinLon|MaxLat|MaxLon|CenterLat|CenterLon```
-``Lat|Lon`` - One per line. As many as PointCount indicates.
+New Airspace: ```ICAO|IsOceanic|IsExtension|PointCount|MinLat|MinLon|MaxLat|MaxLon|CenterLat|CenterLon```
+
+Airspace Points (One per line; as many as ``PointCount`` indicates):
+```Lat|Lon```
 
 <br>
 


### PR DESCRIPTION
The lines starting with ';' seemed not to be interpreted as comments in the FIRBoundaries file, so moved it to the README file instead. Fixes #3 