### PR TITLE
Tehran CTR callsign Change

### DIFF
--- a/VATSpy.dat
+++ b/VATSpy.dat
@@ -135,6 +135,7 @@ India|VO|Control
 Indonesia|WA|
 Indonesia|WI|
 Indonesia|WR|
+Iran|TEH|
 Iran|OI|
 Iraq|OR|
 Ireland|EI|Control


### PR DESCRIPTION
Tehran / Iran vACC have recently changed their CTR callsigns from OIIX to TEH.