### PR TITLE
Change of Swanwick Mil Sector target

### DIFF
--- a/VATSpy.dat
+++ b/VATSpy.dat
@@ -10759,15 +10759,14 @@ EGTT-S|London ACC (South) - London|LTC_SW|EGTT-S
 EGTT-SC|London ACC (South-Central) - London|LON_SC|EGTT-SC
 EGTT-SC|London ACC (South-Central) - London|LTC|EGTT-SC
 EGTT-W|London ACC (West) - London|LON_W|EGTT-W
-EGVV|Swanwick Military|LMLL|EGTT
-EGVV|Swanick Military|SWML|EGTT
-EGVV|Swanick Military|SWMIL|EGTT
-EGVV|Swanick Military|SWAN|EGTT
-EGWD|London Military|LMIL|EGTT
+EGVV|Swanwick Military|LMLL|EGVV
+EGVV|Swanick Military|SWML|EGVV
+EGVV|Swanick Military|SWMIL|EGVV
+EGVV|Swanick Military|SWAN|EGVV
 EGUJ|Neatishead Air Defence|NEAT|EGTT
 EGQN|Buchan Air Defence|BUCH|EGPX
 EGQN|Buchan Air Defence|BUAD|EGPX
-EGQQ|Scottish Military|SMIL|EGPX
+EGQQ|Swanwick Military (North)|SMIL|EGQQ
 EGOM|Spadeadam Range|SPAD|EGTT
 EHAA|Amsterdam||EHAA
 EHMC|Dutch Mil (Military)||EHAA

--- a/VATSpy.dat
+++ b/VATSpy.dat
@@ -10760,9 +10760,9 @@ EGTT-SC|London ACC (South-Central) - London|LON_SC|EGTT-SC
 EGTT-SC|London ACC (South-Central) - London|LTC|EGTT-SC
 EGTT-W|London ACC (West) - London|LON_W|EGTT-W
 EGVV|Swanwick Military|LMLL|EGVV
-EGVV|Swanick Military|SWML|EGVV
-EGVV|Swanick Military|SWMIL|EGVV
-EGVV|Swanick Military|SWAN|EGVV
+EGVV|Swanwick Military|SWML|EGVV
+EGVV|Swanwick Military|SWMIL|EGVV
+EGVV|Swanwick Military|SWAN|EGVV
 EGUJ|Neatishead Air Defence|NEAT|EGTT
 EGQN|Buchan Air Defence|BUCH|EGPX
 EGQN|Buchan Air Defence|BUAD|EGPX


### PR DESCRIPTION
Matches proposed edit to changes to swanwick mil highlighted area in FIRBoundaries. Directs Swanwick Mil to EGVV and Swanwick Mil (North) to EGQQ. 

Spelling of Swanwick corrected from "Swanick" to "Swanwick"

Scottish Mil name changed to Swanwick Mil (North) - reference from VATUK resource: https://prnt.sc/rx9htn

Deleted London Mil as obsolete