### PR TITLE
Set Winnipeg Centre callsign as WPG

### DIFF
--- a/VATSpy.dat
+++ b/VATSpy.dat
@@ -17756,7 +17756,7 @@ CZUL|Montreal|MTL|CZUL
 CZVR|Vancouver|VAN|CZVR
 CZVR|Vancouver|CYVR|CZVR
 CZVR|Vancouver|ZVR|CZVR
-CZWG|Winnipeg|YWG|CZWG
+CZWG|Winnipeg|WPG|CZWG
 CZWG|Winnipeg|ZWG|CZWG
 CZYZ|Toronto|TOR|CZYZ
 DAAA|Algiers||DAAA


### PR DESCRIPTION
Winnipeg is switching it's callsign prefix to WPG effective tomorrow