### PR TITLE
Updated DNKK_CTR to DNKN_CTR

### DIFF
--- a/VATSpy.dat
+++ b/VATSpy.dat
@@ -17812,7 +17812,7 @@ CZYZ|Toronto|TOR|CZYZ
 DAAA|Algiers||DAAA
 DGAC|Accra||DGAC
 DIII|Abidjan||DIII
-DNKK|Kano||DNKK
+DNKN|Kano||DNKK
 DRRR|Niamey||DRRR
 DTTC|Tunis||DTTC
 EBBU|Brussels||EBBU


### PR DESCRIPTION
DNKK is the name for the FIR, however the CTR position is DNKN_CTR. This is amended to show correctly, and I have also made sure that the sector file shows that DNKN_CTR is used, which it does. Evidence available in GNG file.