### PR TITLE
Fixed typo in country description

### DIFF
--- a/VATSpy.dat
+++ b/VATSpy.dat
@@ -322,7 +322,7 @@ Virgin Islands (British)|TU|
 Virgin Islands (US)|TI|
 Wallis and Futuna|NL|
 Yemen|OY|Radio
-Serbia and Montenegro|LY|Radar
+Serbia-Montenegro|LY|Radar
 Zambia|FL|
 Zimbabwe|FV|
 


### PR DESCRIPTION
Changed the country description for ID YU from "Serbia and Montenegro" to "Serbia-Montenegro" in order to

- make clearer this is meant to be two different countries &
- make more consistent with other similar country descriptions (like for ID UT)
