### PR TITLE
UKBC Name change

### DIFF
--- a/VATSpy.dat
+++ b/VATSpy.dat
@@ -12880,7 +12880,7 @@ UIUN|Nizhneangarsk|55.8|109.6||UIII|0
 UIUU|Ulan-Ude (Mukhino)|51.808333|107.441667||UIII|0
 UKAM|Mala Vyska|48.6325|31.614444||UKBV|0
 UKBB|Kyiv (Boryspil)|50.345|30.895|UKBV|UKBV|0
-UKBC|Belaya Tserkov|49.797|30.027||UKBV|0 ; io
+UKBC|Bila Tserkva|49.797|30.027||UKBV|0 ; io
 UKBD|Kyiv/Pivdenyi|50.005|30.197222||UKBV|0
 UKBE|Kaniv (Pekari)|49.697|31.563||UKBV|0
 UKBF|Konotop|51.243|33.152||UKBV|0 ; io


### PR DESCRIPTION
The name of UKBC airport has been updated to reflect the correct name in Ukrainian.
This change was requested and approved by ACCUA01.