### PR TITLE
VATNZ: Add Tasman Sector, slight amendments to others.

### DIFF
--- a/VATSpy.dat
+++ b/VATSpy.dat
@@ -18113,13 +18113,14 @@ NFFF|Nadi Oceanic||NFFF
 NFFN|Nadi||NFFN
 NVVV|Port Vila||NVVV
 NSTU|Pago Pago||NZZO
-NTTT|Tahiti||NTTT
+NTTT|Tahiti Radio||NTTT
 NTTC|Tahiti||NTTC
 NWWW|Noumea||NWWW
 NZZO|Auckland Radio||NZZO
 NZZO|Auckland Radio East|NZZO-E|NZZO
+NZZO|Auckland Radio (Tasman)|NZZO-TSN|NZZO
 NZAA|Auckland||NZAA
-NZAA|Auckland|NZAA-R|NZAA
+NZAA|Auckland (Raglan)|NZAA-R|NZAA
 NZCB|Christchurch (Bay)|NZCH-B|NZCB
 NZCT|Christchurch (Taranaki)|NZCH-T|NZCT
 NZCK|Christchurch (Kaikoura)|NZCH-K|NZCK


### PR DESCRIPTION
Adds NZZO-TSN_FSS, which is a new sub-sector of NZZO. This PR also amends the name of NTTT to reflect the Radio nomenclature, as well as adding the subsector name to NZAA-R.

Tests okay on my end.