### PR TITLE
Change Kurgan (USUU) FIR

### DIFF
--- a/VATSpy.dat
+++ b/VATSpy.dat
@@ -13107,7 +13107,7 @@ USRR|Surgut|61.343333|73.403333||USTV|0
 USSS|Yekaterinburg (Koltsovo)|56.743333|60.805||USSV|0
 USTO|Tobolsk|58.133334|68.233333||USTV|0
 USTR|Tyumen (Roschino)|57.16662|65.316482||USTV|0
-USUU|Kurgan|55.475|65.417||USTV|0 ; corr
+USUU|Kurgan|55.475|65.417||USSV|0 ; corr
 UT0H|Zhaslyk|44.054|57.548||UTTR|0 ; io
 UT0J|Kokand (South East)|40.378|71.093||UTTR|0 ; io (real FIR UTKR)
 UT0N|Kagan|39.689|64.55||UTSD|0 ; io


### PR DESCRIPTION
This change will correct the affiliation of the airport Kurgan to the FIR. For some reason, in the files it is assigned to USTV FIR. In fact, it refers to the USSV.
![image](https://github.com/vatsimnetwork/vatspy-data-project/assets/104563969/17488880-fc5f-443c-914b-951555f3d3ad)
