### PR TITLE
Name change for Centre to Control for EYVL

### DIFF
--- a/VATSpy.dat
+++ b/VATSpy.dat
@@ -168,7 +168,7 @@ Lebanon|OL|Radar
 Lesotho|FX|
 Liberia|GL|
 Libya|HL|Control
-Lithuania|EY|
+Lithuania|EY|Control
 Luxembourg|EL|Control
 Macau|VM|
 Madagascar|FM|


### PR DESCRIPTION
Please change the name for EYVL_CTR. Right now on the map it displays as Vilnius Centre and it's incorrect. Correct one is Vilnius Control. Thank you! Oskaras, ACCLT5.