### PR TITLE
Update VATSpy.dat

### DIFF
--- a/VATSpy.dat
+++ b/VATSpy.dat
@@ -17911,7 +17911,6 @@ EDMM-O|Muenchen ACC (Hof) - Muenchen|EDMM_O|EDMM-O
 EDMM-O|Muenchen ACC (Hof) - Muenchen|EDMM_B|EDMM-O
 EDMM-G|Muenchen ACC (Gera) - Muenchen|EDMM_G|EDMM-G
 EDMM-G|Muenchen ACC (Gera) - Muenchen|EDMM_M|EDMM-G
-EDMM-G|Muenchen ACC (Gera) - Muenchen|EDWW_B|EDMM-G
 EDWW|Bremen||EDWW
 EDWW-B|Bremen ACC (Boerde) - Bremen|EDWW_F|EDWW-B
 EDWW-B|Bremen ACC (Boerde) - Bremen|EDWW_B|EDWW-B


### PR DESCRIPTION
When the EDWW_B_CTR is online, only EDMM_G_CTR is displayed

## Description of changes
Removed EDWW_B_CTR from EDMM_G_CTR


## Reason and motivation
When the EDWW_B_CTR is online, only EDMM_G_CTR is displayed
