### PR TITLE
Added various UK enroute event-only callsigns

### DIFF
--- a/VATSpy.dat
+++ b/VATSpy.dat
@@ -17948,30 +17948,58 @@ EGPX-D|Scottish TMA (Up to FL255) - Scottish|STC_E|EGPX-D
 EGPX-E|Scottish ACC (East) - Scottish|SCO_E|EGPX-E
 EGPX-N|Scottish ACC (North) - Scottish|SCO_N|EGPX-N
 EGPX-S|Scottish ACC (South) - Scottish|SCO_S|EGPX-S
+EGPX-S|Scottish ACC (Tay) - Scottish|SCL_TAY|EGPX-S
 EGPX-WD|Scottish ACC (West/Deancross) - Scottish|SCO_WD|EGPX-WD
 EGPX-W|Scottish ACC (West) - Scottish|SCO_W|EGPX-W
 EGPX-W|Scottish ACC (Rathlin) - Scottish|SCO_R|EGPX-W
 EGPX-A|Scottish TMA Antrim (Up to FL255) - Scottish|STC_A|EGPX-A
 EGTL|London TMA (Up to FL195) - London|LTC|EGTL
 EGTL-N|London TMA North (Up to FL155) - London|LTC_N|EGTL-N
+EGTL-N|London TMA North (Up to FL155) - London|LTC_NE|EGTL-N
+EGTL-N|London TMA North (Up to FL155) - London|LTC_NW|EGTL-N
 EGTL-S|London TMA South (Up to FL195) - London|LTC_S|EGTL-S
+EGTL-S|London TMA South (Up to FL195) - London|LTC_SE|EGTL-S
+EGTL-S|London TMA South (Up to FL195) - London|LTC_SW|EGTL-S
 EGTM|Manchester TMA (Up to FL285) - London|MAN|EGTM
 EGTM-W|Manchester TMA West (Up to FL285) - London|MAN_W|EGTM-W
+EGTM-W|Manchester TMA West (Up to FL285) - London|MAN_WP|EGTM-W
+EGTM-W|Manchester TMA West (Up to FL285) - London|MAN_WI|EGTM-W
 EGTM-NE|Manchester TMA North East (Up to FL285) - London|MAN_NE|EGTM-NE
 EGTM-W|Manchester TMA South East (Up to FL195) - London|MAN_SE|EGTM-W
 EGTT|London|LON|EGTT
 EGTT-C|London ACC (Central) - London|LON_C|EGTT-C
 EGTT-M|London ACC (Daventry) - London|LON_M|EGTT-M
+EGTT-M|London ACC (Daventry) - London|LON_ME|EGTT-M
+EGTT-M|London ACC (Daventry) - London|LON_ML|EGTT-M
+EGTT-M|London ACC (Daventry) - London|LON_MW|EGTT-M
 EGTT-M|London TMA Midlands (Up to FL225) - London|LTC_M|EGTT-M
+EGTT-M|London TMA Midlands (Up to FL225) - London|LTC_MW|EGTT-M
 EGTT-E|London ACC (Clacton) - London|LON_E|EGTT-E
+EGTT-E|London ACC (Clacton) - London|LON_ES|EGTT-E
+EGTT-E|London ACC (Clacton) - London|LON_EN|EGTT-E
 EGTT-E|London TMA East (Up to FL245) - London|LTC_E|EGTT-E
+EGTT-E|London TMA East (Up to FL245) - London|LTC_ES|EGTT-E
+EGTT-E|London TMA East (Up to FL245) - London|LTC_ER|EGTT-E
 EGTT-N|London ACC (North) - London|LON_N|EGTT-N
 EGTT-NE|London ACC (North Sea) - London|LON_NE|EGTT-NE
 EGTT-NW|London ACC (Lakes) - London|LON_NW|EGTT-NW
+EGTT-NW|London ACC (Lakes) - London|LON_NU|EGTT-NW
 EGTT-S|London ACC (South) - London|LON_S|EGTT-S
+EGTT-S|London ACC (Worthing) - London|LON_SF|EGTT-S
+EGTT-S|London ACC (Worthing) - London|LON_SH|EGTT-S
+EGTT-S|London ACC (LUS) - London|LON_SU|EGTT-S
 EGTT-D|London ACC (Dover) - London|LON_D|EGTT-D
+EGTT-D|London ACC (Dover) - London|LON_DK|EGTT-D
+EGTT-D|London ACC (Dover) - London|LON_DL|EGTT-D
 EGTT-SC|London ACC (South-Central) - London|LON_SC|EGTT-SC
 EGTT-W|London ACC (West) - London|LON_W|EGTT-W
+EGTT-W|London ACC (West) - London|LON_WH|EGTT-W
+EGTT-W|London ACC (West) - London|LON_WB|EGTT-W
+EGTT-W|London ACC (West) - London|LON_WL|EGTT-W
+EGTT-W|London ACC (West) - London|LON_23|EGTT-W
+EGTT-W|London ACC (West) - London|LON_8|EGTT-W
+EGTT-W|London ACC (West) - London|LON_WX|EGTT-W
+EGTT-W|London ACC (West) - London|LON_9|EGTT-W
 EGVV|Swanwick Military|EGVV|EGVV
 EGYP|Mount Pleasant (Monte Agradable)|ISLAND|EGYP
 EHAA|Amsterdam||EHAA


### PR DESCRIPTION
## Description of changes
Adds additional callsign patterns for UK enroute positions that are used during events

## Reason and motivation
At the moment, these positions light up the larger defined areas. These additional lines will ensure they sit in the position list for the correct sector group

## Approved contributor?
- [X] I am on the approved contributors list
- [ ] I have sent an request by email to get approved
- [ ] Someone on the approved contributor list will review this request
