### PR TITLE
ZJX Center Splits: DAT file update

### DIFF
--- a/VATSpy.dat
+++ b/VATSpy.dat
@@ -18103,6 +18103,9 @@ KZFW|Fort Worth|FTW|KZFW
 KZHU|Houston|HOU|KZHU
 KZID|Indianapolis|IND|KZID
 KZJX|Jacksonville|JAX|KZJX
+KZJX-P|Jacksonville (Panhandle)|JAX_P|KZJX-P
+KZJX-C|Jacksonville (Central)|JAX_C|KZJX-C
+KZJX-A|Jacksonville (Atlantic)|JAX_A|KZJX-A
 KZKC|Kansas City|MCI|KZKC
 KZKC|Kansas City|KC|KZKC
 KZLA|Los Angeles|LAX|KZLA


### PR DESCRIPTION
Update DAT file to support ZJX splits in addition to ARTCC-wide coverage: Panhandle, Central, and Atlantic.

## Description of changes
At the request of Matt Bromback (ZJX ATM) and with green light from VATUSA, sectorization of ZJX for regular, non-event splits of the airspace similar to ZNY.

## Reason and motivation
From Matt Bromback: "Here at virtual ZJX ARTCC, we are taking a new approach to our extremely busy airspace. Since COVID, pilot traffic has significantly increased, sometimes resulting in frustrations for both pilots and controllers. We are attempting a pilot project similar to VATSIM UK in limiting ATC airspace coverage to provide better services and promote less congestion on frequency."

## Approved contributor?
- [X] I am on the approved contributors list
- [ ] I have sent an request by email to get approved
- [ ] Someone on the approved contributor list will review this request