### PR TITLE
Fix for ZAN boundaries

### DIFF
--- a/VATSpy.dat
+++ b/VATSpy.dat
@@ -18330,10 +18330,10 @@ ORBB-S|Baghdad South||ORBB-N
 OSTT|Damascus|OSDI|OSTT
 OYSC|Sanaa||OYSC
 PAZA|Anchorage||PAZA
-PAZA|Anchorage|ANC|PAZA-D
-PAZA|Anchorage Oceanic - Pacific|ZAN_10|PAZA-P
-PAZA|Anchorage Oceanic - Pacific|ZAN_11|PAZA-P
-PAZA|Anchorage Oceanic - Arctic|ZAN_64|PAZA-A
+PAZA-D|Anchorage|ANC|PAZA-D
+PAZA-P|Anchorage Oceanic - Pacific|ZAN_10|PAZA-P
+PAZA-P|Anchorage Oceanic - Pacific|ZAN_11|PAZA-P
+PAZA-A|Anchorage Oceanic - Arctic|ZAN_64|PAZA-A
 PGZU|Guam|GU|PGZU
 PGZU|Guam|GUM|PGZU
 PGZU|Guam|GUAM|PGZU


### PR DESCRIPTION
## Description of changes
Need to change the "ICAO" of the FIR boundaries as simaware doesn't seem to respect the last field and uses the first to determine which boundaries to draw.

## Reason and motivation
Draw the correct boundaries on simaware, as currently it still draws the entire FIR when only PAZA-D should be drawn. This causes confusion with pilots who use simaware/VATSIM maps to determine when they enter ATC airspace.


## Approved contributior?
<!--- We will only approve changes that is approved from staff -->
<!--- Only select **one** of the following options - Do not select all. -->
- [X] I am on the approved contributers list
- [ ] I have sent an request by email to get approved
- [ ] Someone on the approved contributer list will review this request
