### PR TITLE
Dublin ACC is not in Shannon

### DIFF
--- a/VATSpy.dat
+++ b/VATSpy.dat
@@ -18034,7 +18034,7 @@ EGYP|Mount Pleasant (Monte Agradable)|ISLAND|EGYP
 EHAA|Amsterdam||EHAA
 EHMC|Dutch Mil (Up to FL245)||EHAA
 EHML|Bandbox CRC (Military)||EHAA
-EIDW|Dublin ACC (Up to FL245) - Shannon||EIDW
+EIDW|Dublin ACC (Up to FL245) - Dublin||EIDW
 EISN|Shannon ACC - Shannon||EISN
 EISN-L|Shannon ACC (Up to FL245) - Shannon|EISN_LS|EISN-L
 EKDK|Kobenhavn||EKDK


### PR DESCRIPTION
## Description of changes
Renamed Dublin ACC from Shannon to Dublin


## Reason and motivation
![image](https://github.com/user-attachments/assets/9852589a-6f93-4734-8fe4-190507770f9f)
Currently shows Dublin ACC should be called Shannon Control. This is incorrect. Some pilots incorrectly call Dublin Control "Shannon Control"

## Approved contributior?
<!--- We will only approve changes that is approved from staff -->
<!--- Only select **one** of the following options - Do not select all. -->
- [x] I am on the approved contributers list
- [ ] I have sent an request by email to get approved
- [ ] Someone on the approved contributer list will review this request
