### PR TITLE
Fix airport names for KPQL, KMOB, and KVCT

### DIFF
--- a/VATSpy.dat
+++ b/VATSpy.dat
@@ -19538,5 +19538,4 @@ SAM-W|South America Control West|SCEZ,SCTZ,SCCZ,SCFZ,SLLF,SPIM
 -15.0|-172.5
 -45.0|-172.5
 -52.0|-180.0
-
 -90.0|-180.0


### PR DESCRIPTION
Fix airport names for KPQL, KMOB, and KVCT

## Description of changes
Removed extra default information and validated real-world airport names.

## Reason and motivation
Fix incorrect information based on real-world charts and radio callsigns.

## Approved contributior?
<!--- We will only approve changes that is approved from staff -->
<!--- Only select **one** of the following options - Do not select all. -->
- [X] I am on the approved contributers list
- [ ] I have sent an request by email to get approved
- [ ] Someone on the approved contributer list will review this request
