### PR TITLE
Dispatch Release to CCAMS server

### DIFF
--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -1,0 +1,31 @@
+name: Notify CCAMS Server on release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get App token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.REPO_CCAMS_APP_ID }}
+          private-key: ${{ secrets.REPO_CCAMS_PRIVATE_KEY }}
+          owner: kusterjs
+          repositories: CCAMS-server
+
+      - name: Dispatch to CCAMS Server
+        run: |
+          curl -X POST \
+            -H "Authorization: Bearer ${{ steps.app-token.outputs.token }}" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/kusterjs/CCAMS-server/dispatches \
+            -d '{
+              "event_type": "dispatch-vatspy-data-release",
+              "client_payload": {
+                "repository": "'"${{ github.repository }}"'",
+                "tag": "'"${{ github.event.release.tag_name }}"'"
+              }
+            }'


### PR DESCRIPTION
Request dispatch upon release to CCAMS server repo. Reason: trigger of Mode S capability database.
Please contact me on a private channel to exchange the two secrets required.

## Description of changes
Additional workflow to dispatch an workflow on other (CCAMS server) GitHub repo, collecting then the latest data from vatspy-data-project.


## Reason and motivation
Automation based on trigger event


## Approved contributior?
- [ ] I am on the approved contributers list
- [ ] I have sent an request by email to get approved
- [x] Someone on the approved contributer list will review this request
